### PR TITLE
Include .kitchen.yml attributes to the node file at 'normal' scope.

### DIFF
--- a/lib/kitchen/provisioner/nodes.rb
+++ b/lib/kitchen/provisioner/nodes.rb
@@ -46,6 +46,7 @@ module Kitchen
             :ipaddress => ipaddress,
             :platform => instance.platform.name.split("-")[0].downcase
           },
+          :normal => config[:attributes],
           :run_list => config[:run_list]
         }
 


### PR DESCRIPTION
I added this so that my 2nd node can search for the 1st node using attributes defined in the .kitchen.yml file to simulate the actual runtime environment.
