### PR TITLE
Bump dependency version of test-kitchen.

### DIFF
--- a/kitchen-nodes.gemspec
+++ b/kitchen-nodes.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'net-ping'
   spec.add_dependency 'win32-security'
-  spec.add_dependency 'test-kitchen', '1.4.0.rc.1'
+  spec.add_dependency 'test-kitchen', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency "fakefs",    "~> 0.4"

--- a/lib/kitchen/provisioner/nodes_version.rb
+++ b/lib/kitchen/provisioner/nodes_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Provisioner
 
     # Version string for Nodes Kitchen driver
-    NODES_VERSION = "0.2.0"
+    NODES_VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Test Kitchen 1.4.0 is out.  Let's go ahead and use the released version.