### PR TITLE
Fix search() for currently provisioned node

### DIFF
--- a/lib/kitchen/provisioner/nodes.rb
+++ b/lib/kitchen/provisioner/nodes.rb
@@ -29,8 +29,8 @@ module Kitchen
     class Nodes < ChefZero
       def create_sandbox
         FileUtils.rm(node_file) if File.exist?(node_file)
-        super
         create_node
+        super
       end
 
       def create_node


### PR DESCRIPTION
In order for Chef's search function to find the node which is currently being
provisioned, the .json file that describes it must be part of the sandbox that
gets transferred.  Thus #create_node method must be called *before* #super in
the Kitchen::Provisioner::Nodes#create_sandbox method since Kitchen::Provisioner
::Chef::CommonSandbox#create_sandbox calls `prepare(:nodes)` which just copies
the *current* content of `test/integration/nodes`.