### PR TITLE
Update IP finder to work for CentOS 7.1

### DIFF
--- a/lib/kitchen/provisioner/nodes_version.rb
+++ b/lib/kitchen/provisioner/nodes_version.rb
@@ -19,6 +19,6 @@
 module Kitchen
   # Version string for Nodes Kitchen driver
   module Provisioner
-    NODES_VERSION = '0.3.2'
+    NODES_VERSION = '0.3.3'
   end
 end

--- a/spec/unit/nodes_spec.rb
+++ b/spec/unit/nodes_spec.rb
@@ -125,6 +125,7 @@ describe Kitchen::Provisioner::Nodes do
         FakeFS.activate!
         template.gsub!('1.1.1.1', machine_ips[0])
         template.gsub!('2.2.2.2', machine_ips[1])
+        template.gsub!('3.3.3.3', machine_ips[2])
       end
       let(:transport) { Kitchen::Transport::Ssh.new }
 
@@ -146,6 +147,7 @@ describe Kitchen::Provisioner::Nodes do
           FakeFS.activate!
           template.gsub!('1.1.1.1', machine_ips[0])
           template.gsub!('2.2.2.2', machine_ips[1])
+          template.gsub!('3.3.3.3', machine_ips[2])
         end
 
         before do

--- a/spec/unit/stubs/ifconfig.txt
+++ b/spec/unit/stubs/ifconfig.txt
@@ -24,3 +24,12 @@ lo        Link encap:Local Loopback
           collisions:0 txqueuelen:0
           RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
 
+# The following represents the format of ifconfig from CentOS 7.1
+enp0s8: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 3.3.3.3  netmask 255.255.255.0  broadcast 3.3.3.0
+        inet6 fe80::a00:27ff:fe5e:e9b0  prefixlen 64  scopeid 0x20<link>
+        ether 08:00:27:5e:e9:b0  txqueuelen 1000  (Ethernet)
+        RX packets 7961  bytes 823710 (804.4 KiB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 263  bytes 50868 (49.6 KiB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

--- a/spec/unit/stubs/ip.txt
+++ b/spec/unit/stubs/ip.txt
@@ -7,3 +7,8 @@
 5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default
     inet 2.2.2.2/16 scope global docker0
        valid_lft forever preferred_lft forever
+# The following represents the format of ipaddr from CentOS 7.1 (which is the same in this case, but
+# adding for completeness)
+6: enp0s8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
+    inet 3.3.3.3/24 brd 3.3.3.255 scope global dynamic enp0s8
+       valid_lft 966sec preferred_lft 966sec


### PR DESCRIPTION
The output from ifconfig on CentOS is different from the format which was
present in the existing tests which resulted in the node['ipaddress'] value
being set to '0..5'. Instead of doing string offsets to find the IP, this uses a
regex to find the first quad-octet string that looks like an IP. It's not a
perfect IP matcher, but it works for these scenarios.