### PR TITLE
Added test to check other node's IP is valid

### DIFF
--- a/test/integration/node2/serverspec/default_spec.rb
+++ b/test/integration/node2/serverspec/default_spec.rb
@@ -40,6 +40,10 @@ describe 'other node' do
     expect(ip).not_to eq('127.0.0.1')
   end
 
+  it 'has a valid ip' do
+    expect(ip).to match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+  end
+
   describe command('hostname') do
     its(:stdout) { should_not match(/#{Regexp.quote(fqdn)}/) }
   end


### PR DESCRIPTION
This is in reference to #11, this PR doesn't fix the problem it just provides a ServerSpec test that detects it more helpfully by ensuring the IP address of the other node is basically valid.
This test currently fails like so:
``` 
Failures:

         1) other node has a valid ip
            Failure/Error: expect(ip).to match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
       expected "" to match /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/
```

Indicating that the IP is null in the JSON file.