### PR TITLE
Shave extra newline off fqdn

### DIFF
--- a/lib/kitchen/provisioner/finder/ssh.rb
+++ b/lib/kitchen/provisioner/finder/ssh.rb
@@ -74,7 +74,7 @@ module Kitchen
         end
 
         def find_fqdn
-          @connection.node_execute('hostname -f').chomp
+          @connection.node_execute('hostname -f').chomp.chomp
         end
 
         private

--- a/spec/unit/nodes_spec.rb
+++ b/spec/unit/nodes_spec.rb
@@ -42,7 +42,7 @@ describe Kitchen::Provisioner::Nodes do
       .and_return(Kitchen::Transport::Base::Connection.new)
     allow_any_instance_of(Kitchen::Transport::Base::Connection)
       .to receive(:node_execute).with('hostname -f')
-      .and_return('fakehostname')
+      .and_return("fakehostname\n\n")
   end
   after do
     FakeFS.deactivate!


### PR DESCRIPTION
The output of `hostname -f` seems to be adding two newlines to the
end of it so one chomp isn't enough. This shaves off both newlines
to allow concatenation of things like fqdn and another arbitrary
attribute like port numbers.