### PR TITLE
Fix device filtering breaking for IPv6 interfaces

### DIFF
--- a/lib/kitchen/provisioner/finder/ssh.rb
+++ b/lib/kitchen/provisioner/finder/ssh.rb
@@ -84,6 +84,7 @@ module Kitchen
           ips = []
           response.split(/^\S+/).each do |device|
             next if !device.include?('RUNNING') || device.include?('LOOPBACK')
+            next if IP4REGEX.match(device).nil?
             ips << IP4REGEX.match(device)[1]
           end
           ips.compact


### PR DESCRIPTION
When running kitchen converge I get the following error:

```
$ cat .kitchen/logs/kitchen.log
I, [2016-03-02T14:18:47.025183 #12846]  INFO -- Kitchen: -----> Starting Kitchen (v1.4.2)
I, [2016-03-02T14:18:48.201225 #12846]  INFO -- Kitchen: -----> Converging <influxdb-ubuntu-1404>...
E, [2016-03-02T14:18:52.886025 #12846] ERROR -- Kitchen: ------Exception-------
E, [2016-03-02T14:18:52.886079 #12846] ERROR -- Kitchen: Class: Kitchen::ActionFailed
E, [2016-03-02T14:18:52.886113 #12846] ERROR -- Kitchen: Message: Failed to complete #converge action: [undefined method `[]' for nil:NilClass]
E, [2016-03-02T14:18:52.886157 #12846] ERROR -- Kitchen: ---Nested Exception---
E, [2016-03-02T14:18:52.886175 #12846] ERROR -- Kitchen: Class: NoMethodError
E, [2016-03-02T14:18:52.886210 #12846] ERROR -- Kitchen: Message: undefined method `[]' for nil:NilClass
E, [2016-03-02T14:18:52.886224 #12846] ERROR -- Kitchen: ------Backtrace-------
E, [2016-03-02T14:18:52.886235 #12846] ERROR -- Kitchen: /Users/vervas/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/kitchen-nodes-0.6.6/lib/kitchen/provisioner/finder/ssh.rb:87:in `block in run_ifconfig'
```

This happens when trying to match devices with IPv6 since `IP4REGEX.match(device)` returns `nil`.

Filtering out the devices not matching this regex solves the issue.