### PR TITLE
Allow bypass of state[:hostname] when getting ipaddress

### DIFF
--- a/lib/kitchen/provisioner/nodes.rb
+++ b/lib/kitchen/provisioner/nodes.rb
@@ -54,7 +54,8 @@ module Kitchen
       def ipaddress
         state = state_file
 
-        if %w(127.0.0.1 localhost).include?(state[:hostname])
+        if config[:ignore_statefile_hostname] || \
+           %w(127.0.0.1 localhost).include?(state[:hostname])
           return get_reachable_guest_address(state)
         end
         state[:hostname]


### PR DESCRIPTION
There may be other uses cases which make this helpful, but mine is Openstack, where the state file contains the floating IP but I might want the private IP. True, between the two of them, the floating IP may be the *reachable* one (from the perspective of test-kitchen on the developer's host machine), but 1) You don't always want to be left with the floating IP, as Openstack nodes in the same network can communicate with one another via private IP; and 2) in a Chef recipe running both within and outside test-kitchen, `node.automatic['ipaddress']` exposes the private and not floating IP on an Openstack node.

To force a more ohai-like behavior in this case, you can use the new `ignore_statefile_hostname` attribute pretty simply to opt-in to the proposed logic.

``` yaml
provisioner:
  name: nodes
  ignore_statefile_hostname: true
```