### PR TITLE
Put node object to the "nodes_path" if defined

### DIFF
--- a/lib/kitchen/provisioner/nodes.rb
+++ b/lib/kitchen/provisioner/nodes.rb
@@ -112,7 +112,7 @@ module Kitchen
       # rubocop:enable Metrics/AbcSize
 
       def node_dir
-        File.join(config[:test_base_path], 'nodes')
+        config[:nodes_path] || File.join(config[:test_base_path], 'nodes')
       end
 
       def node_file


### PR DESCRIPTION
There is a major issue when custom `nodes_path` is defined in `.kitchen.yml`. In this case the node object created by `nodes` provisioner is not searchable.

This PR fixes this issue and makes `nodes` provisioner to regard `nodes_path` if it is defined. 