### PR TITLE
Add support for loading roles from .rb and .json

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -18,7 +18,8 @@ platforms:
 suites:
 - name: node1
   run_list:
-  - role[test_role]
+  - role[test_json_role]
+  - role[test_ruby_role]
   - recipe[node-tests::node1]
   attributes:
     consul:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -28,14 +28,15 @@ platforms:
 suites:
 - name: node1
   run_list:
-  - role[test_role]
+  - role[test_json_role]
+  - role[test_ruby_role]
   - recipe[node-tests::node1]
   attributes:
     consul:
       config:
         bootstrap_expect: 2
         server: true
-
+        
 - name: node2
   run_list:
   - recipe[hurry-up-and-test::set_non_nat_vbox_ip]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Metrics/MethodLength:
   Max: 20
 
+Metrics/BlockLength:
+  Max: 150
+
 AllCops:
   Exclude:
   - '.kitchen/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@
 
 gemspec
 
-gem 'kitchen-vagrant'
-gem 'kitchen-docker'
 gem 'berkshelf'
 gem 'chef'
-gem 'winrm-fs', '~> 1.0'
+gem 'kitchen-docker'
+gem 'kitchen-vagrant'
 gem 'pry'
 gem 'rb-readline'
+gem 'winrm-fs', '~> 1.0'

--- a/lib/kitchen/provisioner/run_list_expansion_from_kitchen.rb
+++ b/lib/kitchen/provisioner/run_list_expansion_from_kitchen.rb
@@ -28,8 +28,8 @@ module Kitchen
       end
 
       def fetch_role(name, included_by)
-        role_file = File.join(@role_dir, "#{name}.json")
-        ::Chef::Role.json_create(JSON.parse(File.read(role_file)))
+        role_file = File.join(@role_dir, name)
+        ::Chef::Role.from_disk(role_file)
       rescue ::Chef::Exceptions::RoleNotFound
         role_not_found(name, included_by)
       end

--- a/test/fixtures/roles/test_json_role.json
+++ b/test/fixtures/roles/test_json_role.json
@@ -1,5 +1,5 @@
 {
-  "name": "test_role",
+  "name": "test_json_role",
   "chef_type": "role",
   "json_class": "Chef::Role",
   "default_attributes": {

--- a/test/fixtures/roles/test_ruby_role.rb
+++ b/test/fixtures/roles/test_ruby_role.rb
@@ -1,0 +1,2 @@
+name('test_ruby_role')
+run_list 'recipe[hurry-up-and-test::set_non_nat_vbox_ip]'


### PR DESCRIPTION
This addresses the following deprecation warning and allows for either .json or .rb roles to be used with kitchen-nodes.

rubocop in travis was complaining about gem include ordering and line length with what was already in the repo, fixed that up as well.

```
WARN: Auto inflation of JSON data is deprecated. Please use Chef::Role#from_hash (CHEF-1)