### PR TITLE
do not reset node files at start of converge

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation

--- a/lib/kitchen/provisioner/nodes.rb
+++ b/lib/kitchen/provisioner/nodes.rb
@@ -29,8 +29,9 @@ module Kitchen
     #
     # @author Matt Wrock <matt@mattwrock.com>
     class Nodes < ChefZero
+      default_config :reset_node_files, false
+
       def create_sandbox
-        FileUtils.rm(node_file) if File.exist?(node_file)
         create_node
       ensure
         super
@@ -38,9 +39,24 @@ module Kitchen
 
       def create_node
         FileUtils.mkdir_p(node_dir) unless Dir.exist?(node_dir)
-        template_to_write = node_template
+
+        node_def = if File.exist?(node_file)
+                     updated_node_def
+                   else
+                     node_template
+                   end
+        return unless node_def
+
         File.open(node_file, 'w') do |out|
-          out << JSON.pretty_generate(template_to_write)
+          out << JSON.pretty_generate(node_def)
+        end
+      end
+
+      def updated_node_def
+        if config[:reset_node_files]
+          node_template
+        else
+          nil
         end
       end
 

--- a/lib/kitchen/provisioner/nodes_version.rb
+++ b/lib/kitchen/provisioner/nodes_version.rb
@@ -19,6 +19,6 @@
 module Kitchen
   # Version string for Nodes Kitchen driver
   module Provisioner
-    NODES_VERSION = '0.9.1'.freeze
+    NODES_VERSION = '0.10.0'.freeze
   end
 end


### PR DESCRIPTION
this allows using new `downloads` provisioner config option supported in test-kitchen
https://github.com/test-kitchen/test-kitchen/pull/1306
node files should not be reset at the start of a converge. if you still want this behavior you'll have to enable it:
```yaml
provisioner:
  name: nodes
  reset_node_files: true
```